### PR TITLE
Generalized pval methods to match same statistic as error bars

### DIFF
--- a/benchmark_tools/benchmark_tools.py
+++ b/benchmark_tools/benchmark_tools.py
@@ -6,6 +6,7 @@ import scipy.stats as ss
 from benchmark_tools.constants import (
     METHOD, METRIC, STAT, STD_STATS, PAIRWISE_DEFAULT)
 import benchmark_tools.boot_util as bu
+from benchmark_tools.util import clip_chk
 
 N_BOOT = 1000  # Default number of bootstrap replications
 
@@ -363,7 +364,7 @@ def get_mean_and_EB(x, confidence=0.95, min_EB=0.0,
         assert(False)
 
     # EB subroutines already validated x for shape and nans
-    mu = np.clip(np.mean(x), lower, upper)  # TODO make clip_chk
+    mu = clip_chk(np.mean(x), lower, upper)
     EB = clip_EB(mu, EB, lower, upper, min_EB=min_EB)
     return mu, EB
 
@@ -448,7 +449,7 @@ def get_mean_EB_test(x, confidence=0.95, min_EB=0.0,
         assert(False)
 
     # EB subroutines already validated x for shape and nans
-    mu = np.clip(np.mean(x), lower, upper)  # TODO make clip_chk
+    mu = clip_chk(np.mean(x), lower, upper)
     EB = clip_EB(mu, EB, lower, upper, min_EB=min_EB)
     return mu, EB, pval
 

--- a/benchmark_tools/benchmark_tools.py
+++ b/benchmark_tools/benchmark_tools.py
@@ -78,6 +78,9 @@ def ttest1(x, nan_on_zero=False):
     assert(np.ndim(x) == 1 and len(x) > 0)
     if nan_on_zero and np.all(x[0] == x):
         return np.nan
+    if not np.all(np.isfinite(x)):
+        # It is debatable if this is right action for a single inf.
+        return np.nan
     if len(x) <= 1:
         return 1.0  # Can't say anything about scale => p=1
 

--- a/benchmark_tools/benchmark_tools.py
+++ b/benchmark_tools/benchmark_tools.py
@@ -172,15 +172,17 @@ def bernstein_test(x, lower, upper):
     coef = [(3.0 * range_) / N, std * np.sqrt(2.0 / N), -np.abs(mu)]
     assert(np.all(np.isfinite(coef)))  # Should have caught non-finite cases
     coef_roots = np.roots(coef)
+    assert(len(coef_roots) <= 2)  # This should never happen for quadratic
     assert(coef_roots.dtype.kind == 'f')  # Appears roots are always real
+    print(coef_roots)
+    if len(coef_roots) == 0:
+        print(N, mu, std)
+        print(range_)
+        return 1.0  # TODO figure out this case
     # Appears to always be one neg and one pos root, but we looking for square
     # root so the positive one is the correct one.
-    # TODO make assert
-    if not (len(coef_roots) == 2 and coef_roots[0] <= 0.0 and 0.0 <= coef_roots[1]):
-        print('coeff issue')
-        print(coef_roots)
-    if len(coef_roots) == 0:
-        return 1.0  # TODO figure out this case
+    assert(np.sum(coef_roots <= 0.0) >= 1)
+    assert(np.sum(coef_roots >= 0.0) >= 1)
     B = np.max(coef_roots) ** 2  # Bernstein test statistic
     # Sampling CDF is bounded by exponential for any true distn on x.
     delta = 3.0 * np.exp(-B)

--- a/benchmark_tools/benchmark_tools.py
+++ b/benchmark_tools/benchmark_tools.py
@@ -268,7 +268,7 @@ def _boot_EB_and_test(x, confidence=0.95, n_boot=N_BOOT,
     EB = np.inf
     if return_EB:
         mu = np.mean(x)
-        EB = bu.error_bar(mu_boot, mu, confidence=confidence)    
+        EB = bu.error_bar(mu_boot, mu, confidence=confidence)
 
     # Useful in test:
     CI = -np.inf, np.inf

--- a/benchmark_tools/benchmark_tools.py
+++ b/benchmark_tools/benchmark_tools.py
@@ -7,6 +7,8 @@ from benchmark_tools.constants import (
     METHOD, METRIC, STAT, STD_STATS, PAIRWISE_DEFAULT)
 import benchmark_tools.boot_util as bu
 
+N_BOOT = 1000  # Default number of bootstrap replications
+
 # ============================================================================
 # Statistical util functions
 # ============================================================================
@@ -15,7 +17,7 @@ import benchmark_tools.boot_util as bu
 def clip_EB(mu, EB, lower=-np.inf, upper=np.inf, min_EB=0.0):
     '''Clip error bars to both a minimum uncertainty level and a maximum level
     determined by trivial error bars from the a prior known limits of the
-    unknown parameter `theta`.
+    unknown parameter `theta`. Similar to `np.clip`, but for error bars.
 
     Parameters
     ----------
@@ -40,8 +42,11 @@ def clip_EB(mu, EB, lower=-np.inf, upper=np.inf, min_EB=0.0):
     EB : float
         Error bar after possible clipping.
     '''
-    assert(0.0 <= min_EB and min_EB < np.inf)
+    assert(np.ndim(mu) == 0 and np.ndim(EB) == 0)
+    assert(np.ndim(lower) == 0 and np.ndim(upper) == 0)
     assert(upper - lower >= 0.0)  # Also catch (inf, inf) or nans
+    assert(np.ndim(min_EB) == 0)
+    assert(0.0 <= min_EB and min_EB < np.inf)
 
     # Note: These conditions are designed to pass when NaNs are supplied.
     if lower > mu or mu > upper:
@@ -58,7 +63,7 @@ def clip_EB(mu, EB, lower=-np.inf, upper=np.inf, min_EB=0.0):
     return EB
 
 
-def ttest1(x, nan_on_zero=False):
+def t_test(x):
     '''Perform a standard t-test to test if the values in `x` are sampled from
     a distribution with a zero mean.
 
@@ -66,20 +71,14 @@ def ttest1(x, nan_on_zero=False):
     ----------
     x : array-like, shape (n_samples,)
         array of data points to test.
-    nan_on_zero : bool
-        If True, return a p-value of NaN for samples with identical values.
-        Otherwise, return p=1.0 when `x` is centered on zero, else p=0.0.
 
     Returns
     -------
     pval : float
         p-value (in [0,1]) from t-test on `x`.
     '''
-    assert(np.ndim(x) == 1 and len(x) > 0)
-    assert(not np.any(np.isnan(x)))
+    assert(np.ndim(x) == 1 and (not np.any(np.isnan(x))))
 
-    if nan_on_zero and np.all(x[0] == x):
-        return np.nan
     if (len(x) <= 1) or (not np.all(np.isfinite(x))):
         return 1.0  # Can't say anything about scale => p=1
 
@@ -88,12 +87,10 @@ def ttest1(x, nan_on_zero=False):
         # Should only be possible if scale underflowed to zero:
         assert(np.var(x, ddof=1) <= 1e-100)
         # It is debatable if the condition should be ``np.mean(x) == 0.0`` or
-        # ``np.all(x == 0.0)``
+        # ``np.all(x == 0.0)``. Should not matter in practice.
         pval = np.float(np.mean(x) == 0.0)
     assert(0.0 <= pval and pval <= 1.0)
     return pval
-
-# TODO write stat tests for other EB methods
 
 
 def t_EB(x, confidence=0.95):
@@ -130,6 +127,68 @@ def t_EB(x, confidence=0.95):
     return EB
 
 
+def bernstein_test(x, lower, upper):
+    '''Perform Bernstein bound-based test to test if the values in `x` are
+    sampled from a distribution with a zero mean. This test makes no
+    distributional or central limit theorem assumption on `x`.
+
+    As a result the bound may be loose and the p-value will not be sampled from
+    a uniform distribution under H0 (E[x] = 0), but rather be skewed larger
+    than uniform.
+
+    Parameters
+    ----------
+    x : array-like, shape (n_samples,)
+        array of data points to test.
+    lower : float
+        A priori known theoretical lower limit on unknown mean. For instance,
+        for mean zero-one loss, ``lower=0``.
+    upper : float
+        A priori known theoretical upper limit on unknown mean. For instance,
+        for mean zero-one loss, ``upper=1``.
+
+    Returns
+    -------
+    pval : float
+        p-value (in [0,1]) from t-test on `x`.
+    '''
+    assert(np.ndim(x) == 1 and (not np.any(np.isnan(x))))
+    assert(np.ndim(lower) == 0 and np.ndim(upper) == 0)
+    range_ = upper - lower
+    assert(range_ >= 0.0)  # Also catch (inf, inf) or nans
+    assert(np.all(lower <= x) and np.all(x <= upper))
+
+    if (len(x) <= 1) or (range_ == np.inf) or (not np.all(np.isfinite(x))):
+        # Arguably, we could return p=0, if 0 is outside of [lower, upper], but
+        # it is unclear if there is any advantage to that extra complication.
+        return 1.0  # Can't say anything about scale => p=1
+
+    # Get the moments
+    N = len(x)
+    mu = np.mean(x)
+    std = np.std(x, ddof=0)
+
+    coef = [(3.0 * range_) / N, std * np.sqrt(2.0 / N), -np.abs(mu)]
+    assert(np.all(np.isfinite(coef)))  # Should have caught non-finite cases
+    coef_roots = np.roots(coef)
+    assert(coef_roots.dtype.kind == 'f')  # Appears roots are always real
+    # Appears to always be one neg and one pos root, but we looking for square
+    # root so the positive one is the correct one.
+    # TODO make assert
+    if not (len(coef_roots) == 2 and coef_roots[0] <= 0.0 and 0.0 <= coef_roots[1]):
+        print('coeff issue')
+        print(coef_roots)
+    if len(coef_roots) == 0:
+        return 1.0  # TODO figure out this case
+    B = np.max(coef_roots) ** 2  # Bernstein test statistic
+    # Sampling CDF is bounded by exponential for any true distn on x.
+    delta = 3.0 * np.exp(-B)
+
+    pval = np.minimum(1.0, delta)  # Can cap at 1 to make p-value
+    assert(0.0 <= pval and pval <= 1.0)
+    return pval
+
+
 def bernstein_EB(x, lower, upper, confidence=0.95):
     '''Get Bernstein bound based error bars on mean of `x`. This error bar
     makes no distributional or central limit theorem assumption on `x`.
@@ -139,11 +198,11 @@ def bernstein_EB(x, lower, upper, confidence=0.95):
     x : array-like, shape (n_samples,)
         Data points to estimate mean. Must not be empty or contain NaNs.
     lower : float
-        A priori known theoretical lower limit on unknown parameter `theta`.
-        For instance, for mean zero-one loss, ``lower=0``.
+        A priori known theoretical lower limit on unknown mean. For instance,
+        for mean zero-one loss, ``lower=0``.
     upper : float
-        A priori known theoretical upper limit on unknown parameter `theta`.
-        For instance, for mean zero-one loss, ``upper=1``.
+        A priori known theoretical upper limit on unknown mean. For instance,
+        for mean zero-one loss, ``upper=1``.
     confidence : float
         Confidence probability (in (0, 1)) to construct confidence interval
         from t statistic.
@@ -168,12 +227,12 @@ def bernstein_EB(x, lower, upper, confidence=0.95):
     bandits." Theoretical Computer Science 410.19 (2009): 1876-1902.
     '''
     assert(np.ndim(x) == 1 and (not np.any(np.isnan(x))))
+    assert(np.ndim(lower) == 0 and np.ndim(upper) == 0)
+    range_ = upper - lower
+    assert(range_ >= 0.0)  # Also catch (inf, inf) or nans
     assert(np.all(lower <= x) and np.all(x <= upper))
     assert(np.ndim(confidence) == 0)
     assert(0.0 < confidence and confidence < 1.0)
-
-    range_ = upper - lower
-    assert(range_ >= 0.0)  # Also catch (inf, inf) or nans
 
     N = x.size
     if (N <= 1) or (not np.all(np.isfinite(x))):
@@ -187,31 +246,58 @@ def bernstein_EB(x, lower, upper, confidence=0.95):
     return EB
 
 
-def bernstein_test(x, lower, upper):
-    range_ = upper - lower
-    assert(range_ >= 0.0)  # Also catch (inf, inf) or nans
-    if (len(x) <= 1) or (not np.all(np.isfinite(x))) or (range_ == np.inf):
-        return 1.0  # Can't say anything about scale => p=1
+def _boot_EB_and_test(x, confidence=0.95, n_boot=N_BOOT,
+                      return_EB=True, return_test=True, return_CI=False):
+    '''Internal helper function to compute both bootstrap EB and significance
+    using the same random bootstrap weights, which saves computation and
+    guarantees the results are coherent with each other.'''
+    assert(np.ndim(x) == 1 and (not np.any(np.isnan(x))))
+    # confidence is checked by bu.error_bar
 
-    # Get the moments
-    N = len(x)
-    mu = np.mean(x)
-    std = np.std(x, ddof=0)
+    N = x.size
+    if (N <= 1) or (not np.all(np.isfinite(x))):
+        return np.inf, 1.0, (-np.inf, np.inf)
 
-    coef = [(3.0 * range_) / N, std * np.sqrt(2.0 / N), -np.abs(mu)]
-    assert(np.all(np.isfinite(coef)))  # Should have caught all these cases
-    coef_roots = np.roots(coef)
-    assert(coef_roots.dtype.kind == 'f')  # Appears roots are always real
-    B = np.min(coef_roots ** 2)  # Bernstein test statistic
-    # Sampling CDF bounded by exponential for any true distn.
-    delta = 3.0 * np.exp(-B)
+    weight = bu.boot_weights(N, n_boot)
+    mu_boot = np.mean(x * weight, axis=1)
 
-    pval = np.minimum(1.0, delta)  # Can cap at 1 to make p-value
+    pval = bu.significance(mu_boot, ref=0.0) if return_test else 1.0
+
+    EB = np.inf
+    if return_EB:
+        mu = np.mean(x)
+        EB = bu.error_bar(mu_boot, mu, confidence=confidence)    
+
+    # Useful in test:
+    CI = -np.inf, np.inf
+    if return_CI:
+        CI = bu.percentile(mu_boot, confidence=confidence)
+    return EB, pval, CI
+
+
+def boot_test(x, n_boot=N_BOOT):
+    '''Perform a bootstrap-based test to test if the values in `x` are sampled
+    from a distribution with a zero mean.
+
+    Parameters
+    ----------
+    x : array-like, shape (n_samples,)
+        array of data points to test.
+    n_boot : int
+        Number of bootstrap iterations to perform.
+
+    Returns
+    -------
+    pval : float
+        p-value (in [0,1]) from t-test on `x`.
+    '''
+    _, pval, _ = _boot_EB_and_test(x, n_boot=n_boot,
+                                   return_EB=False, return_test=True)
     assert(0.0 <= pval and pval <= 1.0)
     return pval
 
 
-def boot_EB(x, confidence=0.95, n_boot=1000):
+def boot_EB(x, confidence=0.95, n_boot=N_BOOT):
     '''Get bootstrap bound based error bars on mean of `x`.
 
     Parameters
@@ -230,76 +316,142 @@ def boot_EB(x, confidence=0.95, n_boot=1000):
         Size of error bar on mean (>= 0). The confidence interval is
         ``[mean(x) - EB, mean(x) + EB]``. `EB` is inf when ``len(x) <= 1``.
     '''
-    assert(np.ndim(x) == 1 and (not np.any(np.isnan(x))))
-    N = x.size
-    if (N <= 1) or (not np.all(np.isfinite(x))):
-        return np.inf
-
-    mu = np.mean(x)
-    weight = bu.boot_weights(N, n_boot)
-    mu_boot = np.mean(x * weight, axis=1)
-    EB = bu.error_bar(mu_boot, mu, confidence=confidence)
+    EB, _, _ = _boot_EB_and_test(x, confidence=confidence, n_boot=n_boot,
+                                 return_EB=True, return_test=False)
     assert(np.ndim(EB) == 0 and EB >= 0.0)
     return EB
 
 
-def get_mean_and_EB(loss, loss_ref=0.0, confidence=0.95, min_EB=0.0,
+def get_mean_and_EB(x, confidence=0.95, min_EB=0.0,
                     lower=-np.inf, upper=np.inf, method='t'):
     '''Get mean loss and estimated error bar.
 
     Parameters
     ----------
-    loss : ndarray, shape (n_samples,)
-        Array of loss value where each entry is an independent prediction.
-    loss_ref : float or array-like of shape (n_samples,)
-        Reference values for losses. This may be the losses of another method
-        on the same datapoints. If 1d must be of same size as loss. The error
-        bars are constructed from ``loss - loss_ref`` (like paired test) which
-        results in smaller error bars is the losses are positively correlated.
+    x : ndarray, shape (n_samples,)
+        Array of independent observations.
     confidence : float
         Confidence probability (in (0, 1)) to construct error bar.
     min_EB : float
-        Minimum size of resulting error bar regardless of the data in `loss`.
+        Minimum size of resulting error bar regardless of the data in `x`.
     lower : float
-        A priori known theoretical lower limit on unknown parameter `theta`.
-        For instance, for mean zero-one loss, ``lower=0``.
+        A priori known theoretical lower limit on unknown mean of `x`. For
+        instance, for mean zero-one loss, ``lower=0``.
     upper : float
-        A priori known theoretical upper limit on unknown parameter `theta`.
-        For instance, for mean zero-one loss, ``upper=1``.
+        A priori known theoretical upper limit on unknown mean of `x`. For
+        instance, for mean zero-one loss, ``upper=1``.
     method : {'t', 'bernstein', 'boot'}
         Method to use for building error bar.
 
     Returns
     -------
     mu : float
-        Estimated mean loss.
+        Estimated mean of `x`.
     EB : float
-        Size of error bar on mean loss (``EB > 0``). The confidence interval is
-        ``[mu - EB, mu + EB]``.
+        Size of error bar on mean of `x` (``EB > 0``). The confidence interval
+        is ``[mu - EB, mu + EB]``.
     '''
-    # TODO update doc on lower and upper, must be limits on delta
-    assert(loss.ndim == 1 and np.ndim(loss_ref) <= 1)
-    assert(np.ndim(min_EB) == 0)
-    # EB subroutines all check for presence of nans
-    mu = np.mean(loss)
+    assert(np.all(lower <= x) and np.all(x <= upper))
 
-    # Note we are computing CI on delta to reference!
-    delta = loss - loss_ref
     if method == 't':
-        EB = t_EB(delta, confidence=confidence)
+        EB = t_EB(x, confidence=confidence)
     elif method == 'bernstein':
-        EB = bernstein_EB(delta, lower, upper, confidence=confidence)
+        EB = bernstein_EB(x, lower, upper, confidence=confidence)
     elif method == 'boot':
-        EB = boot_EB(delta, confidence=confidence)
+        EB = boot_EB(x, confidence=confidence)
     else:
         assert(False)
 
-    # TODO might not make sense for pairwise CI
-    EB = clip_EB(np.mean(delta), EB, lower, upper, min_EB=min_EB)
+    # EB subroutines already validated x for shape and nans
+    mu = np.clip(np.mean(x), lower, upper)  # TODO make clip_chk
+    EB = clip_EB(mu, EB, lower, upper, min_EB=min_EB)
     return mu, EB
 
-# just call mean to get CI in main
-# TODO EB should only work on deltas
+
+def get_test(x, lower=-np.inf, upper=np.inf, method='t'):
+    '''Perform a statistical test to determine if the values in `x` are sampled
+    from a distribution with a zero mean.
+
+    Parameters
+    ----------
+    x : ndarray, shape (n_samples,)
+        Array of independent observations.
+    lower : float
+        A priori known theoretical lower limit on unknown mean of `x`. For
+        instance, for mean zero-one loss, ``lower=0``.
+    upper : float
+        A priori known theoretical upper limit on unknown mean of `x`. For
+        instance, for mean zero-one loss, ``upper=1``.
+    method : {'t', 'bernstein', 'boot'}
+        Method to use statistical test.
+
+    Returns
+    -------
+    pval : float
+        p-value (in [0,1]) from statistical test on `x`.
+    '''
+    if method == 't':
+        pval = t_test(x)
+    elif method == 'bernstein':
+        pval = bernstein_test(x, lower, upper)
+    elif method == 'boot':
+        pval = boot_test(x)
+    else:
+        assert(False)
+    return pval
+
+
+def get_mean_EB_test(x, confidence=0.95, min_EB=0.0,
+                     lower=-np.inf, upper=np.inf, method='t'):
+    '''Get mean loss and estimated error bar. Also, perform a statistical test
+    to determine if the values in `x` are sampled from a distribution with a
+    zero mean.
+
+    Parameters
+    ----------
+    x : ndarray, shape (n_samples,)
+        Array of independent observations.
+    confidence : float
+        Confidence probability (in (0, 1)) to construct error bar.
+    min_EB : float
+        Minimum size of resulting error bar regardless of the data in `x`.
+    lower : float
+        A priori known theoretical lower limit on unknown mean of `x`. For
+        instance, for mean zero-one loss, ``lower=0``.
+    upper : float
+        A priori known theoretical upper limit on unknown mean of `x`. For
+        instance, for mean zero-one loss, ``upper=1``.
+    method : {'t', 'bernstein', 'boot'}
+        Method to use for building error bar.
+
+    Returns
+    -------
+    mu : float
+        Estimated mean of `x`.
+    EB : float
+        Size of error bar on mean of `x` (``EB > 0``). The confidence interval
+        is ``[mu - EB, mu + EB]``.
+    pval : float
+        p-value (in [0,1]) from statistical test on `x`.
+    '''
+    assert(np.all(lower <= x) and np.all(x <= upper))
+
+    if method == 't':
+        EB = t_EB(x, confidence=confidence)
+        pval = t_test(x)
+    elif method == 'bernstein':
+        EB = bernstein_EB(x, lower, upper, confidence=confidence)
+        pval = bernstein_test(x, lower, upper)
+    elif method == 'boot':
+        EB, pval, _ = _boot_EB_and_test(x, confidence=confidence)
+    else:
+        assert(False)
+
+    # EB subroutines already validated x for shape and nans
+    mu = np.clip(np.mean(x), lower, upper)  # TODO make clip_chk
+    EB = clip_EB(mu, EB, lower, upper, min_EB=min_EB)
+    return mu, EB, pval
+
 
 # ============================================================================
 # Loss summary: the main purpose of this file.
@@ -372,28 +524,27 @@ def loss_summary_table(loss_table, ref_method, pairwise_CI=PAIRWISE_DEFAULT,
             assert(not np.any(np.isnan(loss)))  # Would let method cheat
             assert(np.all(lower <= loss) and np.all(loss <= upper))
 
-            # TODO new order:
-            # just compute mean
+            mu = np.mean(loss)  # This is the same in all cases
 
-            # Do sig test always pairwise with deltas
-            # compute new bounds, and rand sample seed for boot
+            deltas = loss - loss_ref
+            range_ = upper - lower
+            self_comparison = (method == ref_method)
 
+            EB, pval = np.nan, np.nan
             if pairwise_CI:
-                # TODO use deltas from before if pairwise, pass in seed for
-                # boot. add condition for just nan when method == ref_method.
-                range_ = upper - lower
-                mu, EB = get_mean_and_EB(loss, loss_ref, confidence,
-                                         lower=-range_, upper=range_,
-                                         method=method_EB)
-                # TODO add comment on why here
-                EB = np.nan if method == ref_method else EB
+                if not self_comparison:  # Otherwise leave both as nan
+                    _, EB, pval = get_mean_EB_test(deltas, confidence,
+                                                   lower=-range_, upper=range_,
+                                                   method=method_EB)
             else:
-                mu, EB = get_mean_and_EB(loss, confidence=confidence,
-                                         lower=lower, upper=upper,
-                                         method=method_EB)
+                mu_, EB = get_mean_and_EB(loss, confidence=confidence,
+                                          lower=lower, upper=upper,
+                                          method=method_EB)
+                assert(mu_ == mu)
+                if not self_comparison:  # Otherwise pval as nan
+                    pval = get_test(deltas, lower=-range_, upper=range_,
+                                    method=method_EB)
 
             # This is two-sided, could include one-sided option too.
-            pval = ttest1(loss - loss_ref, nan_on_zero=(method == ref_method))
-            assert((method == ref_method) == np.isnan(pval))
             perf_tbl.loc[method, metric] = (mu, EB, pval)
     return perf_tbl

--- a/benchmark_tools/boot_util.py
+++ b/benchmark_tools/boot_util.py
@@ -81,6 +81,9 @@ def percentile(boot_estimates, confidence=0.95):
     LB_perc, UB_perc = confidence_to_percentiles(confidence)
     # Expand upward to bigger interval for round off. Also, important for
     # keeping CI coherent with signficance test function.
+    # TODO np.percentile does not exactly correspond to mathematical definition
+    # of the quantile function wrt jump locations. And hence may not exactly be
+    # inverse of the ECDF used in significance(). File bug report with numpy.
     LB = np.percentile(boot_estimates, LB_perc, axis=0, interpolation='lower')
     UB = np.percentile(boot_estimates, UB_perc, axis=0, interpolation='higher')
     assert(LB.shape == boot_estimates.shape[1:])
@@ -143,11 +146,6 @@ def error_bar(boot_estimates, original_estimate, confidence=0.95):
     # NaN EB only ever occurs when ref is infinite and so are some samples
     assert(np.all(np.isfinite(original_estimate) <= ~np.isnan(EB)))
     return EB
-
-# TODO test these for consistency against CI
-   # include dupe points, make sure exact when ref in sample
-   # and EB rounds up when not in sample
-# TODO make version that is consistence against basic boot CI
 
 
 def significance(boot_estimates, ref):

--- a/benchmark_tools/classification.py
+++ b/benchmark_tools/classification.py
@@ -200,9 +200,10 @@ def spherical_loss(y, log_pred_prob, rescale=True):
     # Need to do negative of spherical score to make a loss function
     loss = -np.exp(log_pred_prob[np.arange(N), y.astype(int)] - log_normalizer)
 
-    if rescale and n_labels > 1:
-        # Linearly rescale so perfect is 0.0 and uniform gives 1.0
-        c = 1.0 - 1.0 / np.sqrt(n_labels)
+    if rescale:
+        # Linearly rescale so perfect is 0.0 and uniform gives 1.0, when
+        # n_labels = 1 everything is perfect so loss = 0.
+        c = 1.0 - 1.0 / np.sqrt(n_labels) if n_labels > 1 else 1.0
         loss = (1.0 + loss) / c
     return loss
 

--- a/benchmark_tools/util.py
+++ b/benchmark_tools/util.py
@@ -9,6 +9,13 @@ from scipy.misc import logsumexp
 STRICT_SPACING = False
 
 
+def clip_chk(a, a_min, a_max):
+    a_clip = np.clip(a, a_min, a_max)
+    # Check that clipping was small effect
+    assert(np.all((a == a_clip) | np.isclose(a, a_min) | np.isclose(a, a_max)))
+    return a_clip
+
+
 def one_hot(y, n_labels):
     '''Same functionality `sklearn.preprocessing.OneHotEncoder` but avoids
     extra dependency.

--- a/slow_tests/boot_test.py
+++ b/slow_tests/boot_test.py
@@ -10,6 +10,8 @@ import benchmark_tools.perf_curves as pc
 from benchmark_tools.util import area, interp1d
 from benchmark_tools.test_constants import FPR
 
+_FPR = FPR / 3.0  # Divide by number of test funcs
+
 
 def fail_check_stat(fail, runs, expect_p_fail, fpr):
     pvals_2side = [ss.binom_test(ff, runs, expect_p_fail) for ff in fail]
@@ -133,7 +135,7 @@ def test_boot(runs=100):
         fail[10] += fail_EB2
         fail[11] += fail_P2
         fail_curve_prg += fail_curve
-    sub_FPR = FPR / 4.0
+    sub_FPR = _FPR / 4.0
     expect_p_fail = 1.0 - confidence
     fail_check_stat(fail, runs, expect_p_fail, sub_FPR)
     print('ROC curve')
@@ -158,14 +160,50 @@ def test_boot_mean(runs=100):
         EB = bt.boot_EB(x, confidence=0.95)
 
         fail += np.abs(mu - mu_est) > EB
-    # TODO change FPR
     expect_p_fail = 1.0 - confidence
     print('boot mean')
-    fail_check_stat([fail], runs, expect_p_fail, FPR)
+    fail_check_stat([fail], runs, expect_p_fail, _FPR)
+
+
+def test_boot_EB_and_test(runs=100):
+    '''Arguably this should do out to its own file since it tests bt core.'''
+    mu = np.random.randn()
+    stdev = np.abs(np.random.randn())
+
+    N = 201
+    confidence = 0.95
+
+    def run_trial(x, true_value):
+        _, _, CI = bt._boot_EB_and_test(x, confidence=confidence,
+                                        return_CI=True)
+        LB, UB = CI
+        fail_CI = (true_value < LB) or (UB < true_value)
+
+        _, pval, CI = bt._boot_EB_and_test(x - true_value,
+                                           confidence=confidence,
+                                           return_CI=True)
+        LB, UB = CI
+        fail_CI2 = (0 < LB) or (UB < 0)
+        fail_P = pval < 1.0 - confidence
+        return fail_CI, fail_CI2, fail_P
+
+    fail = [0] * 3
+    for ii in range(runs):
+        x = mu + stdev * np.random.randn(N)
+
+        fail_CI, fail_CI2, fail_P = run_trial(x, mu)
+        fail[0] += fail_CI
+        fail[1] += fail_CI2
+        fail[2] += fail_P
+    expect_p_fail = 1.0 - confidence
+    print('boot mean and test')
+    fail_check_stat(fail, runs, expect_p_fail, _FPR)
+
 
 if __name__ == '__main__':
-    np.random.seed(56456 + 11)
+    np.random.seed(56467)
 
     test_boot()
     test_boot_mean()
+    test_boot_EB_and_test()
     print('passed')

--- a/slow_tests/boot_test.py
+++ b/slow_tests/boot_test.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division
 from builtins import range
 import numpy as np
 import scipy.stats as ss
+import benchmark_tools.benchmark_tools as bt
 from benchmark_tools.classification import curve_boot, DEFAULT_NGRID
 import benchmark_tools.constants as cc
 import benchmark_tools.perf_curves as pc
@@ -142,8 +143,29 @@ def test_boot(runs=100):
     print('PRG curve')
     fail_check_stat(fail_curve_prg, runs, expect_p_fail, sub_FPR)
 
+
+def test_boot_mean(runs=100):
+    N = 201
+    confidence = 0.95
+
+    fail = 0
+    for ii in range(runs):
+        mu = np.random.randn()
+        S = np.abs(np.random.randn())
+        x = mu + S * np.random.randn(N)
+
+        mu_est = np.mean(x)
+        EB = bt.boot_EB(x, confidence=0.95)
+
+        fail += np.abs(mu - mu_est) > EB
+    # TODO change FPR
+    expect_p_fail = 1.0 - confidence
+    print('boot mean')
+    fail_check_stat([fail], runs, expect_p_fail, FPR)
+
 if __name__ == '__main__':
-    np.random.seed(56456)
+    np.random.seed(56456 + 11)
 
     test_boot()
+    test_boot_mean()
     print('passed')

--- a/slow_tests/boot_util_test.py
+++ b/slow_tests/boot_util_test.py
@@ -3,7 +3,6 @@ from __future__ import print_function, division
 from builtins import range
 import numpy as np
 import scipy.stats as ss
-import benchmark_tools.benchmark_tools as bt
 import benchmark_tools.boot_util as bu
 from benchmark_tools.test_constants import MC_REPEATS_LARGE, FPR
 
@@ -228,43 +227,6 @@ def inner_test_significance(runs=100):
     return pvals_2side, pvals_1side
 
 
-def inner_test_boot_EB_and_test(runs=100):
-    '''Arguably this should do out to its own file since it tests bt core.'''
-    mu = np.random.randn()
-    stdev = np.abs(np.random.randn())
-
-    N = 201
-    confidence = 0.95
-
-    def run_trial(x, true_value):
-        _, _, CI = bt._boot_EB_and_test(x, confidence=confidence,
-                                        return_CI=True)
-        LB, UB = CI
-        fail_CI = (true_value < LB) or (UB < true_value)
-
-        _, pval, CI = bt._boot_EB_and_test(x - true_value,
-                                           confidence=confidence,
-                                           return_CI=True)
-        LB, UB = CI
-        fail_CI2 = (0 < LB) or (UB < 0)
-        fail_P = pval < 1.0 - confidence
-        return fail_CI, fail_CI2, fail_P
-
-    fail = [0] * 3
-    for ii in range(runs):
-        x = mu + stdev * np.random.randn(N)
-
-        fail_CI, fail_CI2, fail_P = run_trial(x, mu)
-        fail[0] += fail_CI
-        fail[1] += fail_CI2
-        fail[2] += fail_P
-    pvals_2side = [ss.binom_test(ff, runs, 1.0 - confidence) for ff in fail]
-    pvals_1side = \
-        [ss.binom_test(ff, runs, 1.0 - confidence, alternative='greater')
-         for ff in fail]
-    return pvals_2side, pvals_1side
-
-
 def loop_test(test_f):
     runs = 100
     M2 = []
@@ -298,14 +260,8 @@ def test_paired_boot():
 def test_paired_significance():
     loop_test(inner_test_significance)
 
-
-def test_boot_EB_and_test():
-    loop_test(inner_test_boot_EB_and_test)
-
 if __name__ == '__main__':
     np.random.seed(24233)
-
-    test_boot_EB_and_test()
 
     for rr in range(MC_REPEATS_LARGE):
         test_confidence_to_percentiles()

--- a/tests/benchmark_tools_test.py
+++ b/tests/benchmark_tools_test.py
@@ -223,6 +223,7 @@ def test_get_mean_and_EB(runs=10, trials=100):
 
 
 def loss_summary_table_test():
+    # TODO test other EB methods here
     n_labels = np.random.randint(low=1, high=10)
     N = np.random.randint(low=1, high=10)
     n_methods = np.random.randint(low=1, high=5)

--- a/tests/benchmark_tools_test.py
+++ b/tests/benchmark_tools_test.py
@@ -1,32 +1,30 @@
 # Ryan Turner (turnerry@iro.umontreal.ca)
 from __future__ import print_function, division
 from builtins import range
-import warnings
 from string import ascii_letters
 import numpy as np
 import pandas as pd
 import scipy.stats as ss
 import benchmark_tools.benchmark_tools as bt
-import benchmark_tools.classification as btc
-from benchmark_tools import util
+import benchmark_tools.constants as cc
 from benchmark_tools.test_constants import MC_REPEATS_LARGE, FPR
 
 
-def fp_rnd():
+def fp_rnd(allow_nan=False):
     x = np.random.randn()
     if np.random.rand() <= 0.1:
         x = np.inf
     if np.random.rand() <= 0.1:
         x = -np.inf
-    if np.random.rand() <= 0.1:
+    if allow_nan and np.random.rand() <= 0.1:
         x = np.nan
     return x
 
 
 def test_clip_EB(runs=100):
     for _ in range(runs):
-        mu = fp_rnd()
-        EB0 = np.abs(fp_rnd())
+        mu = fp_rnd(allow_nan=True)
+        EB0 = np.abs(fp_rnd(allow_nan=True))
         lower = fp_rnd()
         lower = lower if lower < np.inf else -np.inf
         upper = np.fmax(lower, fp_rnd())
@@ -71,218 +69,378 @@ def test_clip_EB(runs=100):
                                np.fmin(upper, mu + EB)))
 
 
-def test_ttest1():
-    N = np.random.randint(low=1, high=10)
+def test_t_test_to_scipy():
+    N = np.random.randint(low=2, high=10)
     x = np.random.randn(N)
-    x = np.random.choice(np.concatenate(([0], x)), size=N, replace=True)
 
-    all_same = np.all(x[0] == x)
+    _, pval_ss = ss.ttest_1samp(x, 0.0)
+    pval = bt.t_test(x)
+    assert(pval == pval_ss)
 
-    pval0 = bt.ttest1(x, nan_on_zero=False)
-    pval1 = bt.ttest1(x, nan_on_zero=True)
 
-    if all_same:
-        if N <= 1 or x[0] == 0:
-            assert(pval0 == 1.0)
-        else:
-            # Not guaranteed to cause problem in scipy ttest which over-rides
-            # to make p-value 0
-            assert(np.allclose(pval0, 0.0))
-        assert(np.isnan(pval1))
+def test_t_test_on_zero():
+    # Also tests for small N
+    N = np.random.randint(low=0, high=10)
+    x = np.zeros(N)
+
+    pval = bt.t_test(x)
+    assert(pval == 1.0)
+
+
+def test_t_test_zero_var():
+    N = np.random.randint(low=2, high=10)
+    x = np.random.rand() + np.zeros(N)
+    scale = np.exp(np.random.randn()) * np.spacing(x[0])
+    x = scale * np.random.randn(N) + x
+
+    _, pval_ss = ss.ttest_1samp(x, 0.0)
+    pval = bt.t_test(x)
+    if np.isnan(pval_ss):
+        assert(pval == 0.0)  # Not on zero w.p. 1
     else:
-        assert(pval0 == pval1)
-
-        if N <= 1:
-            assert(pval0 == 1.0)
-        else:
-            _, pval_ss = ss.ttest_1samp(x, 0.0)
-            assert(pval0 == pval_ss)
-            assert(0.0 < pval0 and pval0 < 1.0)
-            mu = bt.t_EB(x, confidence=1.0 - pval0)
-            assert(np.allclose(mu, np.abs(np.mean(x))))
-
-    # Now make sure infs work
-    if N >= 1:
-        x[0] = np.random.choice([-np.inf, np.inf])
-        pval0 = bt.ttest1(x, nan_on_zero=False)
-        pval1 = bt.ttest1(x, nan_on_zero=True)
-        assert(pval0 == 1.0)
-        all_same = N == 0 or np.all(x[0] == x)
-        if all_same:
-            assert(np.isnan(pval1))
-        else:
-            assert(pval1 == 1.0)
+        assert(pval == pval_ss)
 
 
-def test_t_EB(runs=10, trials=100):
+def test_t_test_inf():
+    N = np.random.randint(low=1, high=10)
+    x = np.zeros(N)
+    x[0] = np.inf
+    if np.random.rand() <= 0.5:
+        x[0] = -1 * x[0]
+    pval = bt.t_test(x)
+    assert(pval == 1.0)
+
+
+def test_t_EB_zero_var():
+    # Also tests small N
+    N = np.random.randint(low=0, high=10)
+    x = np.random.rand() + np.zeros(N)
+    confidence = np.random.rand()
+    EB = bt.t_EB(x, confidence=confidence)
+    if N <= 1:
+        assert(EB == np.inf)
+    else:
+        assert(np.allclose(EB, 0.0))
+
+
+def test_t_EB_inf():
+    N = np.random.randint(low=1, high=10)
+    x = np.zeros(N)
+    x[0] = np.inf
+    if np.random.rand() <= 0.5:
+        x[0] = -1 * x[0]
+
+    confidence = np.random.rand()
+    EB = bt.t_EB(x, confidence=confidence)
+    assert(EB == np.inf)
+
+
+def test_t_EB_coverage(runs=10, trials=100):
     pval = []
     while len(pval) < runs:
-        N = np.random.randint(low=0, high=10)
+        N = np.random.randint(low=2, high=10)
         confidence = np.random.rand()
 
-        if N <= 1:
+        fail = 0
+        for tt in range(trials):
             x = np.random.randn(N)
-            EB = bt.t_EB(x, confidence=confidence)
-            assert(EB == np.inf)
-        else:
-            fail = 0
-            for tt in range(trials):
-                x = np.random.randn(N)
 
-                EB = bt.t_EB(x, confidence=confidence)
-                mu = np.nanmean(x)
-                LB, UB = mu - EB, mu + EB
-                assert(np.isfinite(LB) and np.isfinite(UB))
-                fail += (0.0 < LB) or (UB < 0.0)
-            pval.append(ss.binom_test(fail, trials, 1.0 - confidence))
+            EB = bt.t_EB(x, confidence=confidence)
+            mu = np.nanmean(x)
+            LB, UB = mu - EB, mu + EB
+            assert(np.isfinite(LB) and np.isfinite(UB))
+            fail += (0.0 < LB) or (UB < 0.0)
+        pval.append(ss.binom_test(fail, trials, 1.0 - confidence))
     _, pval_agg = ss.combine_pvalues(pval)
     return pval_agg
 
 
-def test_bernstein_EB(runs=10, trials=100):
+def test_t_test_to_EB():
+    N = np.random.randint(low=2, high=10)
+    x = np.random.randn(N)
+
+    pval = bt.t_test(x)
+    EB = bt.t_EB(x, confidence=1.0 - pval)
+    assert(np.allclose(np.abs(np.mean(x)), EB))
+
+
+def test_bernstein_test_inf():
+    N = np.random.randint(low=1, high=10)
+    x = np.zeros(N)
+    x[0] = np.inf
+    if np.random.rand() <= 0.5:
+        x[0] = -1 * x[0]
+
+    lower = np.minimum(np.min(x), np.random.randn())
+    upper = np.maximum(np.max(x), np.random.randn())
+
+    pval = bt.bernstein_test(x, lower, upper)
+    assert(pval == 1.0)
+
+
+def test_bernstein_EB_inf():
+    N = np.random.randint(low=1, high=10)
+    x = np.zeros(N)
+    x[0] = np.inf
+    if np.random.rand() <= 0.5:
+        x[0] = -1 * x[0]
+
+    lower = np.minimum(np.min(x), np.random.randn())
+    upper = np.maximum(np.max(x), np.random.randn())
+
+    confidence = np.random.rand()
+    EB = bt.bernstein_EB(x, lower, upper, confidence=confidence)
+    assert(EB == np.inf)
+
+
+def test_bernstein_EB_coverage(runs=10, trials=100):
     pval = []
     while len(pval) < runs:
-        N = np.random.randint(low=0, high=10)
+        # Crank up N to test this bound
+        N = np.random.randint(low=200, high=1000)
         confidence = np.random.rand()
 
         lower = np.random.randn()
         upper = lower + np.abs(np.random.randn())
 
-        if N <= 1:
+        fail = 0
+        for tt in range(trials):
             x = np.random.uniform(lower, upper, size=N)
-            EB = bt.bernstein_EB(x, lower, upper, confidence=confidence)
-            assert(np.allclose(EB, upper - lower))
-        else:
-            fail = 0
-            for tt in range(trials):
-                # Crank up N to test this bound
-                x = np.random.uniform(lower, upper, size=100 * N)
-                true_mu = (lower + upper) / 2
+            true_mu = (lower + upper) / 2
 
-                EB = bt.bernstein_EB(x, lower, upper, confidence=confidence)
-                mu = np.mean(x)
-                LB, UB = mu - EB, mu + EB
-                assert(np.isfinite(LB) and np.isfinite(UB))
-                fail += (true_mu < LB) or (UB < true_mu)
-            pval.append(ss.binom_test(fail, trials, 1.0 - confidence,
-                                      alternative='greater'))
+            EB = bt.bernstein_EB(x, lower, upper, confidence=confidence)
+            mu = np.mean(x)
+            LB, UB = mu - EB, mu + EB
+            assert(np.isfinite(LB) and np.isfinite(UB))
+            fail += (true_mu < LB) or (UB < true_mu)
+        # Must use one-sided test since the bernstein bound can be loose.
+        pval.append(ss.binom_test(fail, trials, 1.0 - confidence,
+                                  alternative='greater'))
     _, pval_agg = ss.combine_pvalues(pval)
     return pval_agg
 
 
-# TODO test other forms of EB
-# will need to use one sided test for bernstein
-# maybe put in slow_tests
+def test_bernstein_test_to_EB():
+    N = np.random.randint(low=0, high=25)
+    lower = np.random.randn()
+    upper = lower + np.abs(np.random.randn())
+    x = np.random.uniform(lower, upper, size=N)
+    if N >= 1:
+        x[0] = np.clip(0, lower, upper)
+    x = np.random.choice(x, size=N, replace=True)
 
-def test_get_mean_and_EB(runs=10, trials=100):
-    # TODO test bernstein and boot as well, will need one sided
+    pval = bt.bernstein_test(x, lower, upper)
+    EB = bt.bernstein_EB(x, lower, upper, confidence=1.0 - pval)
+    if pval == 1.0:
+        assert(EB == upper - lower)
+    else:
+        assert(np.allallclose(np.abs(np.mean(x)), EB))
 
-    pval = []
-    while len(pval) < runs:
-        N = np.random.randint(low=0, high=10)
+
+def test_boot_EB_and_test():
+    seed_iter = np.random.randint(0, 10 ** 6, size=MC_REPEATS_LARGE)
+    for seed in seed_iter:
+        N = np.random.randint(1, 20)
+        x = np.random.randn(N)
+        x[0] = 0
+        x = np.random.choice(x, size=N, replace=True)
+        x[0] = 0  # At least one, maybe more zeros
+        mu = np.mean(x)
         confidence = np.random.rand()
 
-        if N <= 1:
-            x = 2.0 + np.random.randn(N)
-            x_ref = 1.5 + np.random.randn(N)
+        np.random.seed(seed)
+        EB, pval, CI = bt._boot_EB_and_test(x, confidence=confidence,
+                                            return_CI=True)
+        #assert(mu - EB <= CI[0])
+        #assert(CI[1] <= mu + EB)  # TODO enable
+        assert(np.allclose(mu - EB, CI[0]) or np.allclose(mu + EB, CI[1]))
 
-            with warnings.catch_warnings():  # expect warning for N=0
-                warnings.simplefilter('ignore', RuntimeWarning)
-                mu, EB = bt.get_mean_and_EB(x, x_ref, confidence=confidence)
-                assert(np.allclose(mu, np.nanmean(mu), equal_nan=True))
-                assert(EB == np.inf)
+        np.random.seed(seed)
+        pval_ = bt.boot_test(x)
+        assert(pval == pval_)
 
-                mu, EB = bt.get_mean_and_EB(x, confidence=confidence)
-                mu2, EB2 = bt.get_mean_and_EB(x, np.zeros_like(x),
-                                          confidence=confidence)
-                assert(np.allclose(mu, np.nanmean(mu2), equal_nan=True))
-                assert(np.allclose(EB, np.nanmean(EB2), equal_nan=True))
+        np.random.seed(seed)
+        EB_ = bt.boot_EB(x, confidence=confidence)
+        assert(EB == EB_)
+
+        #np.random.seed(seed)
+        #pval_adj = np.nextafter(1.0, 0.0) if pval == 1.0 else pval
+        #EB, pval_, CI = bt._boot_EB_and_test(x, confidence=1.0 - pval_adj,
+        #                                     return_CI=True)
+        #assert(pval == pval_)
+        #assert(mu - EB <= CI[0])
+        #assert(CI[1] <= mu + EB)
+        # assert(CI[0] == 0.0 or CI[1] == 0.0)  # TODO enable
+
+
+def test_get_mean_EB_test():
+    seed_iter = np.random.randint(0, 10 ** 6, size=MC_REPEATS_LARGE)
+    for seed in seed_iter:
+        N = np.random.randint(1, 20)
+        x = np.random.randn(N)
+        x[0] = 0
+        x = np.random.choice(x, size=N, replace=True)
+        mu = np.mean(x)
+        confidence = np.random.rand()
+
+        lower = np.min(x) - np.maximum(0.0, fp_rnd())
+        upper = np.max(x) + np.maximum(0.0, fp_rnd())
+        min_EB = np.clip(np.random.randn(), 0.0, 0.5 * (upper - lower))
+        method = np.random.choice(['t', 'bernstein', 'boot'])
+
+        np.random.seed(seed)
+        mu_, EB, pval = \
+            bt.get_mean_EB_test(x, confidence=confidence, min_EB=min_EB,
+                                lower=lower, upper=upper, method=method)
+        assert(np.allclose(mu, mu_))
+
+        np.random.seed(seed)
+        mu_, EB_ = bt.get_mean_and_EB(x, confidence=confidence, min_EB=min_EB,
+                                      lower=lower, upper=upper, method=method)
+        assert(np.allclose(mu, mu_))
+        assert(EB_ == EB)
+
+        np.random.seed(seed)
+        pval_ = bt.get_test(x, lower=lower, upper=upper, method=method)
+        assert(pval_ == pval)
+
+        np.random.seed(seed)
+        if method == 't':
+            EB_ = bt.t_EB(x, confidence=confidence)
+        elif method == 'bernstein':
+            EB_ = bt.bernstein_EB(x, lower=lower, upper=upper,
+                              confidence=confidence)
         else:
-            fail = 0
-            for tt in range(trials):
-                x = 2.0 + np.random.randn(N)
-                x_ref = 1.5 + np.random.randn(N)
+            EB_ = bt.boot_EB(x, confidence=confidence)
+        assert(EB_ >= EB or EB == min_EB)  # EB_ is pre-clip
+        assert(EB == EB_ or EB == min_EB or
+               np.allclose(mu - EB, lower) or np.allclose(mu + EB, upper))
 
-                # TODO test again that min_EB increases it to min_EB
-                # also try throwing in lower and upper near where EB is
+        np.random.seed(seed)
+        if method == 't':
+            pval_ = bt.t_test(x)
+        elif method == 'bernstein':
+            pval_ = bt.bernstein_test(x, lower=lower, upper=upper)
+        else:
+            pval_ = bt.boot_test(x)
+        assert(pval_ == pval)
 
-                mu, EB = bt.get_mean_and_EB(x, x_ref, confidence=confidence)
-                assert(np.isfinite(mu) and np.isfinite(EB))
-                assert(np.allclose(mu, np.nanmean(mu), equal_nan=True))
-                err = np.nanmean(x - x_ref) - 0.5
-                fail += np.abs(err) > EB
-
-                mu, EB = bt.get_mean_and_EB(x, confidence=confidence)
-                mu2, EB2 = bt.get_mean_and_EB(x, np.zeros_like(x),
-                                              confidence=confidence)
-                assert(np.allclose(mu, np.nanmean(mu2), equal_nan=True))
-                assert(np.allclose(EB, np.nanmean(EB2), equal_nan=True))
-            pval.append(ss.binom_test(fail, trials, 1.0 - confidence))
-    _, pval_agg = ss.combine_pvalues(pval)
-    return pval_agg
+# TODO MC test coverage of boot but point into slows test
 
 
-def loss_summary_table_test():
-    # TODO test other EB methods here
-    n_labels = np.random.randint(low=1, high=10)
+def test_loss_summary_table():
     N = np.random.randint(low=1, high=10)
     n_methods = np.random.randint(low=1, high=5)
-
+    n_metrics = np.random.randint(low=1, high=5)
     confidence = np.random.rand()
-    pairwise_CI = np.random.rand() <= 0.5
+    # Would be good to test 'boot' too, but too much hassle with random seeds
+    method_EB = np.random.choice(['t', 'bernstein'])
 
     methods = np.random.choice(list(ascii_letters), n_methods, replace=False)
-    ref = np.random.choice(methods)
-    metrics = btc.STD_CLASS_LOSS
-    labels = range(n_labels)
+    ref_method = np.random.choice(methods)
+    metrics = np.random.choice(list(ascii_letters), n_metrics, replace=False)
 
-    col_names = pd.MultiIndex.from_product([methods, labels],
-                                           names=[bt.METHOD, btc.LABEL])
-    dat = np.random.randn(N, n_labels * len(methods))
-    tbl = pd.DataFrame(data=dat, index=range(N), columns=col_names,
-                       dtype=float)
+    cols = pd.MultiIndex.from_product([metrics, methods],
+                                      names=[cc.METRIC, cc.METHOD])
+    dat = np.random.randn(N, n_metrics * n_methods)
+    tbl = pd.DataFrame(data=dat, index=range(N), columns=cols, dtype=float)
 
-    y = np.random.randint(low=0, high=n_labels, size=N)
-    loss_tbl = btc.loss_table(tbl, y, metrics_dict=metrics)
-    perf_tbl = bt.loss_summary_table(loss_tbl, ref, pairwise_CI=pairwise_CI,
-                                     confidence=confidence)
-    for metric, metric_f in metrics.items():
-        loss_ref = metric_f(y, util.normalize(tbl[ref].values))
+    limits = {mm: (np.min(tbl[mm].values) - np.maximum(0.0, fp_rnd()),
+                   np.max(tbl[mm].values) + np.maximum(0.0, fp_rnd()))
+              for mm in metrics}
+    del limits[metrics[0]]  # Also test missing
+
+    print(tbl)
+    perf_tbl = bt.loss_summary_table(tbl, ref_method, pairwise_CI=False,
+                                     confidence=confidence,
+                                     method_EB=method_EB, limits=limits)
+    perf_tbl_p = bt.loss_summary_table(tbl, ref_method, pairwise_CI=True,
+                                       confidence=confidence,
+                                       method_EB=method_EB, limits=limits)
+
+    # Test pairwise vs non-pairwise off EB
+    mean_df = perf_tbl.xs(cc.MEAN_COL, axis=1, level=1)
+    assert(mean_df.equals(perf_tbl_p.xs(cc.MEAN_COL, axis=1, level=1)))
+    pval_df = perf_tbl.xs(cc.PVAL_COL, axis=1, level=1)
+    assert(pval_df.equals(perf_tbl_p.xs(cc.PVAL_COL, axis=1, level=1)))
+
+    # Test nan pattern
+    assert(not np.any(np.isnan(mean_df.values)))
+    assert(np.all(np.isnan(pval_df.loc[ref_method, :].values)))
+    other_pvals = pval_df.loc[pval_df.index != ref_method, :].values
+    assert(np.all(0.0 <= other_pvals) and np.all(other_pvals <= 1.0))
+    EB_df = perf_tbl.xs(cc.ERR_COL, axis=1, level=1)
+    assert(np.all(EB_df >= 0.0))
+    EB_df = perf_tbl_p.xs(cc.ERR_COL, axis=1, level=1)
+    assert(np.all(np.isnan(EB_df.loc[ref_method, :].values)))
+    other_EB = EB_df.loc[pval_df.index != ref_method, :].values
+    assert(np.all(0.0 <= other_EB))
+
+    # Now non-vectorized test
+    for metric in metrics:
+        lower, upper = limits.get(metric, (-np.inf, np.inf))
+        range_ = upper - lower
+        loss_sub = tbl[metric]
+        ref_x = loss_sub[ref_method].values
         for method in methods:
-            loss = metric_f(y, util.normalize(tbl[method].values))
-            assert(np.allclose(loss_tbl[(metric, method)].values, loss,
-                               equal_nan=True))
+            x = loss_sub[method].values
 
-            if pairwise_CI:
-                mu, EB = bt.get_mean_and_EB(loss=loss, loss_ref=loss_ref,
-                                            confidence=confidence)
-                if method == ref:
-                    EB = np.nan
-            else:
-                mu, EB = bt.get_mean_and_EB(loss=loss, confidence=confidence)
+            mu, EB, pval = perf_tbl.loc[method, metric].values
+            mu_p, EB_p, pval_p = perf_tbl_p.loc[method, metric].values
+            assert(mu == np.mean(x))
+            assert(mu == mu_p)
 
-            delta = loss - loss_ref
-            if method == ref:
-                pval = np.nan
-            elif len(delta) == 1:
-                pval = 1.0
-            elif np.std(delta) == 0.0:
-                pval = np.float(np.all(delta == 0.0))
+            # Non-pairwise EB
+            _, EB_ = bt.get_mean_and_EB(x, confidence=confidence,
+                                        lower=lower, upper=upper,
+                                        method=method_EB)
+            assert(EB == EB_)
+
+            # Pairwise EB
+            if method == ref_method:
+                assert(np.isnan(EB_p))
             else:
-                _, pval = ss.ttest_1samp(delta, 0.0)
-            assert(np.allclose(perf_tbl.loc[method, metric].values,
-                               [mu, EB, pval], equal_nan=True))
+                _, EB_ = bt.get_mean_and_EB(x - ref_x, confidence=confidence,
+                                            lower=-range_, upper=range_,
+                                            method=method_EB)
+                assert(EB_p == EB_)
+
+            # P-vals
+            if method == ref_method:
+                assert(np.isnan(pval))
+                assert(np.isnan(pval_p))
+            else:
+                pval_ = bt.get_test(x - ref_x, lower=-range_, upper=range_,
+                                    method=method_EB)
+                assert(pval == pval_p)
+                assert(pval == pval_)
+
 
 if __name__ == '__main__':
-    np.random.seed(53634 + 199)
+    np.random.seed(85634)
 
-    for _ in range(MC_REPEATS_LARGE):
+    for rr in range(MC_REPEATS_LARGE):
         test_clip_EB()
-        test_ttest1()
-        loss_summary_table_test()
+        test_t_test_to_scipy()
+        test_t_test_on_zero()
+        test_t_test_zero_var()
+        test_t_test_inf()
+        test_t_EB_zero_var()
+        test_t_EB_inf()
+        test_t_test_to_EB()
+        test_bernstein_test_inf()
+        test_bernstein_EB_inf()
+        # test_bernstein_test_to_EB()  # TODO enable
+        # This is a big one, we could put in loop with less iters:
+        test_loss_summary_table()
+        print(rr)
+
+    # Already have for loop built in
+    test_boot_EB_and_test()
+    test_get_mean_EB_test()
 
     print('Now running MC tests')
-    test_list = [test_t_EB, test_bernstein_EB, test_get_mean_and_EB]
+    test_list = [test_t_EB_coverage, test_bernstein_EB_coverage]
     for test_f in test_list:
         pval = test_f(trials=MC_REPEATS_LARGE)
         print(pval)

--- a/tests/benchmark_tools_test.py
+++ b/tests/benchmark_tools_test.py
@@ -334,7 +334,7 @@ def test_get_mean_EB_test():
             EB_ = bt.t_EB(x, confidence=confidence)
         elif method == 'bernstein':
             EB_ = bt.bernstein_EB(x, lower=lower, upper=upper,
-                              confidence=confidence)
+                                  confidence=confidence)
         else:
             EB_ = bt.boot_EB(x, confidence=confidence)
         assert(EB_ >= EB or EB == min_EB)  # EB_ is pre-clip

--- a/tests/benchmark_tools_test.py
+++ b/tests/benchmark_tools_test.py
@@ -234,7 +234,18 @@ def test_bernstein_test_to_EB():
         x[0] = np.clip(0, lower, upper)
         x = np.random.choice(x, size=N, replace=True)
 
+    EB = bt.bernstein_EB(x, lower, upper, confidence=0.95)
     pval = bt.bernstein_test(x, lower, upper)
+    if N >= 1:
+        mu = np.mean(x)
+        LB, UB = mu - EB, mu + EB
+        # Sanity check pval even if really small and not well numerically
+        # invertible.
+        if pval <= 0.05:
+            assert(close_lte(0, LB) or close_lte(UB, 0))
+        else:
+            assert(close_lte(LB, 0) or close_lte(0, UB))
+
     epsilon = np.spacing(1.0)
     pval_adj = np.clip(pval, epsilon, 1.0 - epsilon)
     EB = bt.bernstein_EB(x, lower, upper, confidence=1.0 - pval_adj)
@@ -431,6 +442,7 @@ if __name__ == '__main__':
     np.random.seed(85634)
 
     # Already have for-loop built in
+    # TODO bring back
     #test_boot_EB_and_test()
     #test_get_mean_EB_test()
 

--- a/tests/benchmark_tools_test.py
+++ b/tests/benchmark_tools_test.py
@@ -273,7 +273,7 @@ def loss_summary_table_test():
                                [mu, EB, pval], equal_nan=True))
 
 if __name__ == '__main__':
-    np.random.seed(53634)
+    np.random.seed(53634 + 199)
 
     for _ in range(MC_REPEATS_LARGE):
         test_clip_EB()

--- a/tests/benchmark_tools_test.py
+++ b/tests/benchmark_tools_test.py
@@ -89,6 +89,11 @@ def test_clip_EB(runs=100):
             assert(np.allclose(np.fmin(upper, mu + EB0),
                                np.fmin(upper, mu + EB)))
 
+# TODO include test of ttest1
+#     make sure always nan for non-finite
+#     test both nan on zero and not
+#     test scales that produce underflow
+
 
 def test_t_EB(runs=10, trials=100):
     pval = []
@@ -114,8 +119,16 @@ def test_t_EB(runs=10, trials=100):
     _, pval_agg = ss.combine_pvalues(pval)
     return pval_agg
 
+# TODO test other forms of EB
+# will need to use one sided test for bernstein
+# maybe put in slow_tests
+
+
+
 
 def test_get_mean_and_EB(runs=10, trials=100):
+    # TODO test bernstein and boot as well, will need one sided
+
     pval = []
     while len(pval) < runs:
         N = np.random.randint(low=0, high=10)
@@ -142,6 +155,9 @@ def test_get_mean_and_EB(runs=10, trials=100):
                 x = 2.0 + np.random.randn(N)
                 x_ref = 1.5 + np.random.randn(N)
 
+                # TODO test again that min_EB increases it to min_EB
+                # also try throwing in lower and upper near where EB is
+
                 mu, EB = bt.get_mean_and_EB(x, x_ref, confidence=confidence)
                 assert(np.isfinite(mu) and np.isfinite(EB))
                 assert(np.allclose(mu, np.nanmean(mu), equal_nan=True))
@@ -156,6 +172,8 @@ def test_get_mean_and_EB(runs=10, trials=100):
             pval.append(ss.binom_test(fail, trials, 1.0 - confidence))
     _, pval_agg = ss.combine_pvalues(pval)
     return pval_agg
+
+# TODO pull these guys out into test classification
 
 
 def hard_loss_binary_test():

--- a/tests/benchmark_tools_test.py
+++ b/tests/benchmark_tools_test.py
@@ -442,9 +442,8 @@ if __name__ == '__main__':
     np.random.seed(85634)
 
     # Already have for-loop built in
-    # TODO bring back
-    #test_boot_EB_and_test()
-    #test_get_mean_EB_test()
+    test_boot_EB_and_test()
+    test_get_mean_EB_test()
 
     for rr in range(MC_REPEATS_LARGE):
         test_clip_EB()

--- a/tests/benchmark_tools_test.py
+++ b/tests/benchmark_tools_test.py
@@ -336,8 +336,6 @@ def test_get_mean_EB_test():
             pval_ = bt.boot_test(x)
         assert(pval_ == pval)
 
-# TODO MC test coverage of boot but point into slows test
-
 
 def test_loss_summary_table():
     N = np.random.randint(low=1, high=10)
@@ -429,7 +427,7 @@ def test_loss_summary_table():
 if __name__ == '__main__':
     np.random.seed(85634)
 
-    # Already have for loop built in
+    # Already have for-loop built in
     test_boot_EB_and_test()
     test_get_mean_EB_test()
 

--- a/tests/benchmark_tools_test.py
+++ b/tests/benchmark_tools_test.py
@@ -232,14 +232,17 @@ def test_bernstein_test_to_EB():
     x = np.random.uniform(lower, upper, size=N)
     if N >= 1:
         x[0] = np.clip(0, lower, upper)
-    x = np.random.choice(x, size=N, replace=True)
+        x = np.random.choice(x, size=N, replace=True)
 
     pval = bt.bernstein_test(x, lower, upper)
-    EB = bt.bernstein_EB(x, lower, upper, confidence=1.0 - pval)
-    if pval == 1.0:
-        assert(EB == upper - lower)
-    else:
-        assert(np.allallclose(np.abs(np.mean(x)), EB))
+    epsilon = np.spacing(1.0)
+    pval_adj = np.clip(pval, epsilon, 1.0 - epsilon)
+    EB = bt.bernstein_EB(x, lower, upper, confidence=1.0 - pval_adj)
+    # p-value very small, might not expect this to pass due to numerics, if
+    # p-value = 1 then it was clipped and can't invert since we don't have
+    # original.
+    if 1e-6 <= pval and pval < 1.0:
+        assert(np.allclose(np.abs(np.mean(x)), EB))
 
 
 def test_boot_EB_and_test():
@@ -428,8 +431,8 @@ if __name__ == '__main__':
     np.random.seed(85634)
 
     # Already have for-loop built in
-    test_boot_EB_and_test()
-    test_get_mean_EB_test()
+    #test_boot_EB_and_test()
+    #test_get_mean_EB_test()
 
     for rr in range(MC_REPEATS_LARGE):
         test_clip_EB()
@@ -442,7 +445,7 @@ if __name__ == '__main__':
         test_t_test_to_EB()
         test_bernstein_test_inf()
         test_bernstein_EB_inf()
-        # test_bernstein_test_to_EB()  # TODO enable
+        test_bernstein_test_to_EB()
         # This is a big one, we could put in loop with less iters:
         test_loss_summary_table()
         print(rr)

--- a/tests/benchmark_tools_test.py
+++ b/tests/benchmark_tools_test.py
@@ -6,29 +6,10 @@ from string import ascii_letters
 import numpy as np
 import pandas as pd
 import scipy.stats as ss
-from sklearn.metrics import brier_score_loss, log_loss, zero_one_loss
 import benchmark_tools.benchmark_tools as bt
 import benchmark_tools.classification as btc
 from benchmark_tools import util
 from benchmark_tools.test_constants import MC_REPEATS_LARGE, FPR
-
-
-def hard_loss_binary(y_bool, log_pred_prob, FP_cost=1.0):
-    '''Special case of hard_loss.'''
-    N, n_labels = btc.shape_and_validate(y_bool, log_pred_prob)
-    assert(n_labels == 2)
-    assert(FP_cost > 0.0)
-
-    FN_cost = 1.0
-    thold = np.log(FP_cost / (FP_cost + FN_cost))
-
-    y_bool = y_bool.astype(bool)  # So we can use ~
-    yhat = log_pred_prob[:, 1] >= thold
-    assert(y_bool.dtype.kind == 'b' and yhat.dtype.kind == 'b')
-
-    loss = (~y_bool * yhat) * FP_cost + (y_bool * ~yhat) * FN_cost
-    assert(np.all((loss == 0) | (loss == FN_cost) | (loss == FP_cost)))
-    return loss
 
 
 def fp_rnd():
@@ -89,10 +70,48 @@ def test_clip_EB(runs=100):
             assert(np.allclose(np.fmin(upper, mu + EB0),
                                np.fmin(upper, mu + EB)))
 
-# TODO include test of ttest1
-#     make sure always nan for non-finite
-#     test both nan on zero and not
-#     test scales that produce underflow
+
+def test_ttest1():
+    N = np.random.randint(low=1, high=10)
+    x = np.random.randn(N)
+    x = np.random.choice(np.concatenate(([0], x)), size=N, replace=True)
+
+    all_same = np.all(x[0] == x)
+
+    pval0 = bt.ttest1(x, nan_on_zero=False)
+    pval1 = bt.ttest1(x, nan_on_zero=True)
+
+    if all_same:
+        if N <= 1 or x[0] == 0:
+            assert(pval0 == 1.0)
+        else:
+            # Not guaranteed to cause problem in scipy ttest which over-rides
+            # to make p-value 0
+            assert(np.allclose(pval0, 0.0))
+        assert(np.isnan(pval1))
+    else:
+        assert(pval0 == pval1)
+
+        if N <= 1:
+            assert(pval0 == 1.0)
+        else:
+            _, pval_ss = ss.ttest_1samp(x, 0.0)
+            assert(pval0 == pval_ss)
+            assert(0.0 < pval0 and pval0 < 1.0)
+            mu = bt.t_EB(x, confidence=1.0 - pval0)
+            assert(np.allclose(mu, np.abs(np.mean(x))))
+
+    # Now make sure infs work
+    if N >= 1:
+        x[0] = np.random.choice([-np.inf, np.inf])
+        pval0 = bt.ttest1(x, nan_on_zero=False)
+        pval1 = bt.ttest1(x, nan_on_zero=True)
+        assert(pval0 == 1.0)
+        all_same = N == 0 or np.all(x[0] == x)
+        if all_same:
+            assert(np.isnan(pval1))
+        else:
+            assert(pval1 == 1.0)
 
 
 def test_t_EB(runs=10, trials=100):
@@ -119,12 +138,41 @@ def test_t_EB(runs=10, trials=100):
     _, pval_agg = ss.combine_pvalues(pval)
     return pval_agg
 
+
+def test_bernstein_EB(runs=10, trials=100):
+    pval = []
+    while len(pval) < runs:
+        N = np.random.randint(low=0, high=10)
+        confidence = np.random.rand()
+
+        lower = np.random.randn()
+        upper = lower + np.abs(np.random.randn())
+
+        if N <= 1:
+            x = np.random.uniform(lower, upper, size=N)
+            EB = bt.bernstein_EB(x, lower, upper, confidence=confidence)
+            assert(np.allclose(EB, upper - lower))
+        else:
+            fail = 0
+            for tt in range(trials):
+                # Crank up N to test this bound
+                x = np.random.uniform(lower, upper, size=100 * N)
+                true_mu = (lower + upper) / 2
+
+                EB = bt.bernstein_EB(x, lower, upper, confidence=confidence)
+                mu = np.mean(x)
+                LB, UB = mu - EB, mu + EB
+                assert(np.isfinite(LB) and np.isfinite(UB))
+                fail += (true_mu < LB) or (UB < true_mu)
+            pval.append(ss.binom_test(fail, trials, 1.0 - confidence,
+                                      alternative='greater'))
+    _, pval_agg = ss.combine_pvalues(pval)
+    return pval_agg
+
+
 # TODO test other forms of EB
 # will need to use one sided test for bernstein
 # maybe put in slow_tests
-
-
-
 
 def test_get_mean_and_EB(runs=10, trials=100):
     # TODO test bernstein and boot as well, will need one sided
@@ -172,112 +220,6 @@ def test_get_mean_and_EB(runs=10, trials=100):
             pval.append(ss.binom_test(fail, trials, 1.0 - confidence))
     _, pval_agg = ss.combine_pvalues(pval)
     return pval_agg
-
-# TODO pull these guys out into test classification
-
-
-def hard_loss_binary_test():
-    '''Also tests hard loss.'''
-    n_labels = 2
-    N = np.random.randint(low=1, high=10)
-
-    y_bool = np.random.rand(N) <= 0.5
-    y_pred = util.normalize(np.random.randn(N, n_labels))
-    loss = hard_loss_binary(y_bool, y_pred)
-
-    act = btc.hard_loss_decision(y_pred, 1.0 - np.eye(n_labels))
-    loss2 = zero_one_loss(y_bool.astype(int), act)
-    assert(np.allclose(np.mean(loss), loss2))
-
-    loss2 = btc.hard_loss(y_bool, y_pred)
-    assert(np.allclose(loss, loss2))
-
-
-def hard_loss_decision_test():
-    n_labels = np.random.randint(low=1, high=10)
-    n_act = np.random.randint(low=1, high=10)
-    N = np.random.randint(low=0, high=10)
-
-    y_pred = util.normalize(np.random.randn(N, n_labels))
-
-    act = btc.hard_loss_decision(y_pred, 1.0 - np.eye(n_labels))
-    assert(np.all(np.argmax(y_pred, axis=1) == act))
-
-    loss_mat = np.random.rand(n_labels, n_act)
-    act = btc.hard_loss_decision(y_pred, loss_mat)
-
-    loss_mat = np.concatenate((loss_mat, np.ones((n_labels, 1))), axis=1)
-    act2 = btc.hard_loss_decision(y_pred, loss_mat)
-    assert(np.all(act == act2))
-
-    loss_mat = np.concatenate((loss_mat, np.zeros((n_labels, 1))), axis=1)
-    act2 = btc.hard_loss_decision(y_pred, loss_mat)
-    assert(np.all(act2 == loss_mat.shape[1] - 1))
-
-
-def log_loss_test():
-    n_labels = np.random.randint(low=1, high=10)
-    N = np.random.randint(low=1, high=10)
-
-    y = np.random.randint(low=0, high=n_labels, size=N)
-    y_pred = util.normalize(np.random.randn(N, n_labels))
-
-    if n_labels >= 2:
-        loss = btc.log_loss(y, y_pred)
-
-        loss2 = log_loss(y, np.exp(y_pred), labels=range(n_labels))
-        assert(np.allclose(np.mean(loss), loss2))
-
-    with np.errstate(invalid='ignore', divide='ignore'):
-        pred = np.log(util.one_hot(y, n_labels))
-    loss2 = btc.log_loss(y, pred)
-    assert(np.max(np.abs(loss2)) <= 1e-8)
-
-
-def brier_loss_test():
-    n_labels = np.random.randint(low=1, high=4)
-    N = np.random.randint(low=1, high=10)
-
-    y = np.random.randint(low=0, high=n_labels, size=N)
-    y_pred = util.normalize(np.random.randn(N, n_labels))
-
-    loss = btc.brier_loss(y, y_pred, rescale=False)
-    # sklearn learn is dumb and gets confused when only one class passed in
-    if n_labels == 2 and np.std(y) >= 1e-8:
-        loss2 = brier_score_loss(y == 1, np.exp(y_pred[:, 1]), pos_label=True)
-        assert(np.allclose(np.mean(loss), 2.0 * loss2))
-
-    with np.errstate(invalid='ignore', divide='ignore'):
-        pred = np.log(util.one_hot(y, n_labels))
-    loss2 = btc.brier_loss(y, pred, rescale=False)
-    assert(np.max(np.abs(loss2)) <= 1e-8)
-
-
-def spherical_loss_test():
-    n_labels = np.random.randint(low=1, high=10)
-    N = np.random.randint(low=1, high=10)
-
-    y = np.random.randint(low=0, high=n_labels, size=N)
-    y_pred = util.normalize(np.random.randn(N, n_labels))
-
-    loss = btc.spherical_loss(y, y_pred, rescale=False)
-
-    # Check against the linear implementation
-    pred_prob = np.exp(y_pred)
-    normalizer = np.sqrt(np.sum(pred_prob ** 2, axis=1))
-    loss_0 = -pred_prob[np.arange(N), y.astype(int)] / normalizer
-    assert(np.allclose(loss, loss_0, equal_nan=True))
-
-    with np.errstate(invalid='ignore', divide='ignore'):
-        pred = np.log(util.one_hot(y, n_labels))
-    loss2 = btc.spherical_loss(y, pred, rescale=False)
-    assert(np.max(np.abs(loss2 + 1.0)) <= 1e-8)
-
-    if n_labels >= 2:
-        with np.errstate(invalid='ignore', divide='ignore'):
-            pred_prob = util.normalize(np.log(1.0 - util.one_hot(y, n_labels)))
-        loss2 = btc.spherical_loss(y, pred_prob, rescale=False)
-        assert(np.max(np.abs(loss2)) <= 1e-8)
 
 
 def loss_summary_table_test():
@@ -335,18 +277,13 @@ if __name__ == '__main__':
 
     for _ in range(MC_REPEATS_LARGE):
         test_clip_EB()
-        hard_loss_binary_test()
-        hard_loss_decision_test()
-        log_loss_test()
-        brier_loss_test()
-        spherical_loss_test()
+        test_ttest1()
         loss_summary_table_test()
 
     print('Now running MC tests')
-    pval = test_t_EB(trials=MC_REPEATS_LARGE)
-    print(pval)
-    assert(pval >= FPR / 2.0)
-    pval = test_get_mean_and_EB(trials=MC_REPEATS_LARGE)
-    print(pval)
-    assert(pval >= FPR / 2.0)
+    test_list = [test_t_EB, test_bernstein_EB, test_get_mean_and_EB]
+    for test_f in test_list:
+        pval = test_f(trials=MC_REPEATS_LARGE)
+        print(pval)
+        assert(pval >= FPR / len(test_list))
     print('passed')

--- a/tests/classification_test.py
+++ b/tests/classification_test.py
@@ -1,0 +1,149 @@
+# Ryan Turner (turnerry@iro.umontreal.ca)
+from __future__ import print_function, absolute_import, division
+import numpy as np
+from sklearn.metrics import brier_score_loss, log_loss, zero_one_loss
+import benchmark_tools.classification as btc
+from benchmark_tools import util
+from benchmark_tools.test_constants import MC_REPEATS_LARGE
+
+
+def hard_loss_binary(y_bool, log_pred_prob, FP_cost=1.0):
+    '''Special case of hard_loss.'''
+    N, n_labels = btc.shape_and_validate(y_bool, log_pred_prob)
+    assert(n_labels == 2)
+    assert(FP_cost > 0.0)
+
+    FN_cost = 1.0
+    thold = np.log(FP_cost / (FP_cost + FN_cost))
+
+    y_bool = y_bool.astype(bool)  # So we can use ~
+    yhat = log_pred_prob[:, 1] >= thold
+    assert(y_bool.dtype.kind == 'b' and yhat.dtype.kind == 'b')
+
+    loss = (~y_bool * yhat) * FP_cost + (y_bool * ~yhat) * FN_cost
+    assert(np.all((loss == 0) | (loss == FN_cost) | (loss == FP_cost)))
+    return loss
+
+# TODO change _test order in func name
+
+def hard_loss_decision_test():
+    n_labels = np.random.randint(low=1, high=10)
+    n_act = np.random.randint(low=1, high=10)
+    N = np.random.randint(low=0, high=10)
+
+    y_pred = util.normalize(np.random.randn(N, n_labels))
+
+    act = btc.hard_loss_decision(y_pred, 1.0 - np.eye(n_labels))
+    assert(np.all(np.argmax(y_pred, axis=1) == act))
+
+    loss_mat = np.random.rand(n_labels, n_act)
+    act = btc.hard_loss_decision(y_pred, loss_mat)
+
+    loss_mat = np.concatenate((loss_mat, np.ones((n_labels, 1))), axis=1)
+    act2 = btc.hard_loss_decision(y_pred, loss_mat)
+    assert(np.all(act == act2))
+
+    loss_mat = np.concatenate((loss_mat, np.zeros((n_labels, 1))), axis=1)
+    act2 = btc.hard_loss_decision(y_pred, loss_mat)
+    assert(np.all(act2 == loss_mat.shape[1] - 1))
+
+
+def hard_loss_binary_test():
+    '''Also tests hard loss.'''
+    n_labels = 2
+    N = np.random.randint(low=1, high=10)
+
+    y_bool = np.random.rand(N) <= 0.5
+    y_pred = util.normalize(np.random.randn(N, n_labels))
+    loss = hard_loss_binary(y_bool, y_pred)
+
+    act = btc.hard_loss_decision(y_pred, 1.0 - np.eye(n_labels))
+    loss2 = zero_one_loss(y_bool.astype(int), act)
+    assert(np.allclose(np.mean(loss), loss2))
+
+    loss2 = btc.hard_loss(y_bool, y_pred)
+    assert(np.allclose(loss, loss2))
+
+
+def log_loss_test():
+    n_labels = np.random.randint(low=1, high=10)
+    N = np.random.randint(low=1, high=10)
+
+    y = np.random.randint(low=0, high=n_labels, size=N)
+    y_pred = util.normalize(np.random.randn(N, n_labels))
+
+    if n_labels >= 2:
+        loss = btc.log_loss(y, y_pred)
+
+        loss2 = log_loss(y, np.exp(y_pred), labels=range(n_labels))
+        assert(np.allclose(np.mean(loss), loss2))
+
+    with np.errstate(invalid='ignore', divide='ignore'):
+        pred = np.log(util.one_hot(y, n_labels))
+    loss2 = btc.log_loss(y, pred)
+    assert(np.max(np.abs(loss2)) <= 1e-8)
+
+# TODO test with rescale=True
+
+def brier_loss_test():
+    n_labels = np.random.randint(low=1, high=4)
+    N = np.random.randint(low=1, high=10)
+
+    y = np.random.randint(low=0, high=n_labels, size=N)
+    y_pred = util.normalize(np.random.randn(N, n_labels))
+
+    loss = btc.brier_loss(y, y_pred, rescale=False)
+    # sklearn learn is dumb and gets confused when only one class passed in
+    if n_labels == 2 and np.std(y) >= 1e-8:
+        loss2 = brier_score_loss(y == 1, np.exp(y_pred[:, 1]), pos_label=True)
+        assert(np.allclose(np.mean(loss), 2.0 * loss2))
+
+    with np.errstate(invalid='ignore', divide='ignore'):
+        pred = np.log(util.one_hot(y, n_labels))
+    loss2 = btc.brier_loss(y, pred, rescale=False)
+    assert(np.max(np.abs(loss2)) <= 1e-8)
+
+
+def spherical_loss_test():
+    n_labels = np.random.randint(low=1, high=10)
+    N = np.random.randint(low=1, high=10)
+
+    y = np.random.randint(low=0, high=n_labels, size=N)
+    y_pred = util.normalize(np.random.randn(N, n_labels))
+
+    loss = btc.spherical_loss(y, y_pred, rescale=False)
+
+    # Check against the linear implementation
+    pred_prob = np.exp(y_pred)
+    normalizer = np.sqrt(np.sum(pred_prob ** 2, axis=1))
+    loss_0 = -pred_prob[np.arange(N), y.astype(int)] / normalizer
+    assert(np.allclose(loss, loss_0, equal_nan=True))
+
+    with np.errstate(invalid='ignore', divide='ignore'):
+        pred = np.log(util.one_hot(y, n_labels))
+    loss2 = btc.spherical_loss(y, pred, rescale=False)
+    assert(np.max(np.abs(loss2 + 1.0)) <= 1e-8)
+
+    if n_labels >= 2:
+        with np.errstate(invalid='ignore', divide='ignore'):
+            pred_prob = util.normalize(np.log(1.0 - util.one_hot(y, n_labels)))
+        loss2 = btc.spherical_loss(y, pred_prob, rescale=False)
+        assert(np.max(np.abs(loss2)) <= 1e-8)
+
+# TODO test loss table
+
+# TODO note that curves done in boot
+
+# TODO test rest of classification
+
+
+if __name__ == '__main__':
+    np.random.seed(845412)
+
+    for _ in range(MC_REPEATS_LARGE):
+        hard_loss_binary_test()
+        hard_loss_decision_test()
+        log_loss_test()
+        brier_loss_test()
+        spherical_loss_test()
+    print('passed')

--- a/tests/classification_test.py
+++ b/tests/classification_test.py
@@ -82,8 +82,6 @@ def test_log_loss():
     loss2 = btc.log_loss(y, pred)
     assert(np.max(np.abs(loss2)) <= 1e-8)
 
-# TODO test with rescale=True
-
 
 def test_brier_loss():
     n_labels = np.random.randint(low=1, high=4)
@@ -102,6 +100,15 @@ def test_brier_loss():
         pred = np.log(util.one_hot(y, n_labels))
     loss2 = btc.brier_loss(y, pred, rescale=False)
     assert(np.max(np.abs(loss2)) <= 1e-8)
+    loss2 = btc.brier_loss(y, pred, rescale=True)
+    assert(np.max(np.abs(loss2)) <= 1e-8)
+
+    pred = util.normalize(np.zeros((N, n_labels)))
+    loss2 = btc.brier_loss(y, pred, rescale=True)
+    if n_labels >= 2:
+        assert(np.max(np.abs(loss2 - 1.0)) <= 1e-8)
+    else:
+        assert(np.max(np.abs(loss2)) <= 1e-8)
 
 
 def test_spherical_loss():
@@ -123,12 +130,18 @@ def test_spherical_loss():
         pred = np.log(util.one_hot(y, n_labels))
     loss2 = btc.spherical_loss(y, pred, rescale=False)
     assert(np.max(np.abs(loss2 + 1.0)) <= 1e-8)
+    loss2 = btc.spherical_loss(y, pred, rescale=True)
+    assert(np.max(np.abs(loss2)) <= 1e-8)
 
     if n_labels >= 2:
         with np.errstate(invalid='ignore', divide='ignore'):
             pred_prob = util.normalize(np.log(1.0 - util.one_hot(y, n_labels)))
         loss2 = btc.spherical_loss(y, pred_prob, rescale=False)
         assert(np.max(np.abs(loss2)) <= 1e-8)
+
+        loss2 = btc.spherical_loss(y, util.normalize(np.zeros((N, n_labels))),
+                                   rescale=True)
+        assert(np.max(np.abs(loss2 - 1.0)) <= 1e-8)
 
 # Note: btc.curve_boot is tested in slow_tests/boot_test.py
 

--- a/tests/classification_test.py
+++ b/tests/classification_test.py
@@ -24,10 +24,8 @@ def hard_loss_binary(y_bool, log_pred_prob, FP_cost=1.0):
     assert(np.all((loss == 0) | (loss == FN_cost) | (loss == FP_cost)))
     return loss
 
-# TODO change _test order in func name
 
-
-def hard_loss_decision_test():
+def test_hard_loss_decision():
     n_labels = np.random.randint(low=1, high=10)
     n_act = np.random.randint(low=1, high=10)
     N = np.random.randint(low=0, high=10)
@@ -49,7 +47,7 @@ def hard_loss_decision_test():
     assert(np.all(act2 == loss_mat.shape[1] - 1))
 
 
-def hard_loss_binary_test():
+def test_hard_loss_binary():
     '''Also tests hard loss.'''
     n_labels = 2
     N = np.random.randint(low=1, high=10)
@@ -66,7 +64,7 @@ def hard_loss_binary_test():
     assert(np.allclose(loss, loss2))
 
 
-def log_loss_test():
+def test_log_loss():
     n_labels = np.random.randint(low=1, high=10)
     N = np.random.randint(low=1, high=10)
 
@@ -87,7 +85,7 @@ def log_loss_test():
 # TODO test with rescale=True
 
 
-def brier_loss_test():
+def test_brier_loss():
     n_labels = np.random.randint(low=1, high=4)
     N = np.random.randint(low=1, high=10)
 
@@ -106,7 +104,7 @@ def brier_loss_test():
     assert(np.max(np.abs(loss2)) <= 1e-8)
 
 
-def spherical_loss_test():
+def test_spherical_loss():
     n_labels = np.random.randint(low=1, high=10)
     N = np.random.randint(low=1, high=10)
 
@@ -132,20 +130,15 @@ def spherical_loss_test():
         loss2 = btc.spherical_loss(y, pred_prob, rescale=False)
         assert(np.max(np.abs(loss2)) <= 1e-8)
 
-# TODO test loss table
-
-# TODO note that curves done in boot
-
-# TODO test rest of classification
-
+# Note: btc.curve_boot is tested in slow_tests/boot_test.py
 
 if __name__ == '__main__':
     np.random.seed(845412)
 
     for _ in range(MC_REPEATS_LARGE):
-        hard_loss_binary_test()
-        hard_loss_decision_test()
-        log_loss_test()
-        brier_loss_test()
-        spherical_loss_test()
+        test_hard_loss_binary()
+        test_hard_loss_decision()
+        test_log_loss()
+        test_brier_loss()
+        test_spherical_loss()
     print('passed')

--- a/tests/classification_test.py
+++ b/tests/classification_test.py
@@ -26,6 +26,7 @@ def hard_loss_binary(y_bool, log_pred_prob, FP_cost=1.0):
 
 # TODO change _test order in func name
 
+
 def hard_loss_decision_test():
     n_labels = np.random.randint(low=1, high=10)
     n_act = np.random.randint(low=1, high=10)
@@ -84,6 +85,7 @@ def log_loss_test():
     assert(np.max(np.abs(loss2)) <= 1e-8)
 
 # TODO test with rescale=True
+
 
 def brier_loss_test():
     n_labels = np.random.randint(low=1, high=4)


### PR DESCRIPTION
Now use a test statistic matching the error bar method (such as boot or bernstein) when computing the significance of the performance vs the metric.  Before a t-test was the only option.  Now, use the the same statistic as was selected for the error bars.  Also, re-wrote the tests for benchmark_tools.py.